### PR TITLE
Fix missing groupname

### DIFF
--- a/app/src/main/java/nz/org/cacophony/sidekick/CacophonyAPI.kt
+++ b/app/src/main/java/nz/org/cacophony/sidekick/CacophonyAPI.kt
@@ -86,13 +86,15 @@ class CacophonyAPI(@Suppress("UNUSED_PARAMETER") context :Context) {
                     .addFormDataPart("data", data.toString())
                     .build()
 
-            var endpoint="";
+            var endpoint :String
             if (recording.deviceID > 0) {
                 endpoint = "device/${recording.deviceID}"
             } else {
-                endpoint = "device/${recording.deviceName}/group/${recording.groupName}"
+                endpoint = "device/${recording.deviceName}"
+                if (recording.groupName != null && recording.groupName != "") {
+                    endpoint += "/group/${recording.groupName}"
+                }
             }
-
             val request = Request.Builder()
                     .url("${getServerURL(c)}/api/v1/recordings/${endpoint}")
                     .addHeader("Authorization", getJWT(c))

--- a/app/src/main/java/nz/org/cacophony/sidekick/Device.kt
+++ b/app/src/main/java/nz/org/cacophony/sidekick/Device.kt
@@ -47,7 +47,17 @@ class Device(
         Log.i(TAG, "Created new device: $name")
         makeDeviceDir()
         thread(start = true) {
-            checkConnectionStatus()
+            for (i in 3.downTo(0)) {
+                checkConnectionStatus()
+                if (sm.state == DeviceState.CONNECTED) {
+                    break
+                }
+                if (i > 0) {
+                    Log.i(TAG, "failed to connect to interface, trying $i more times")
+                } else {
+                    Log.e(TAG, "failed to connect to interface")
+                }
+            }
             getDeviceInfo()
             updateRecordings()
         }


### PR DESCRIPTION
- Prevent API requests with missing groupname causing a 404
- Retry connecting to the interface before getting device info. Prevents making deivce-info API requests when the interface is not yet up. 