### PR TITLE
update device file path

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -39,7 +39,7 @@ android {
         vectorDrawables.useSupportLibrary = true
         applicationId "nz.org.cacophony.sidekick"
         minSdkVersion project.ext.minimumSdkVersion
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode generateVersionCode()
         versionName generateVersionName()
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/main/java/nz/org/cacophony/sidekick/Device.kt
+++ b/app/src/main/java/nz/org/cacophony/sidekick/Device.kt
@@ -279,7 +279,7 @@ class Device(
     }
 
     private fun getDeviceDir(): File {
-        return File("${Environment.getExternalStorageDirectory()}/cacophony-sidekick/$name")
+        return File("${activity.getExternalFilesDir(null)}/devices/$name")
     }
 
     private fun makeDeviceDir(): Boolean {


### PR DESCRIPTION
`Environment.getExternalStorageDirectory()` is deprecated and did not work with android 10 and a targetSdkVersion of 29
- Changing storage location won't mean that older recordings that were collected will be lost as the recording file path is stored in the recordings database.