### PR TITLE
Added option to change storage location and update settings page

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -39,7 +39,7 @@ android {
         vectorDrawables.useSupportLibrary = true
         applicationId "nz.org.cacophony.sidekick"
         minSdkVersion project.ext.minimumSdkVersion
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode generateVersionCode()
         versionName generateVersionName()
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/main/java/nz/org/cacophony/sidekick/Device.kt
+++ b/app/src/main/java/nz/org/cacophony/sidekick/Device.kt
@@ -279,7 +279,8 @@ class Device(
     }
 
     private fun getDeviceDir(): File {
-        return File("${Environment.getExternalStorageDirectory()}/cacophony-sidekick/$name")
+        val prefs = Preferences(activity.applicationContext)
+        return File("${prefs.getString(STORAGE_LOCATION)}/devices/$name")
     }
 
     private fun makeDeviceDir(): Boolean {

--- a/app/src/main/java/nz/org/cacophony/sidekick/MainViewModel.kt
+++ b/app/src/main/java/nz/org/cacophony/sidekick/MainViewModel.kt
@@ -41,11 +41,16 @@ class MainViewModel : ViewModel() {
         networkIntentFilter.addAction("android.net.wifi.WIFI_STATE_CHANGED")
         networkIntentFilter.addAction("android.net.wifi.WIFI_AP_STATE_CHANGED")
 
-        val prefs = Preferences(activity)
-        storageLocation.value = prefs.getString(STORAGE_LOCATION)
-        if (storageLocation.value == "") {
-            storageLocation.value = activity.applicationContext.getExternalFilesDir(null)!!.path
-            prefs.setString(STORAGE_LOCATION, storageLocation.value!!)
+        storageLocation.value = Preferences(activity).getString(STORAGE_LOCATION)
+        if (storageLocation.value == null) {
+            loadDefaultStoragePath(activity.applicationContext)
         }
+    }
+
+    fun loadDefaultStoragePath(c: Context): Boolean {
+        val extPath = c.getExternalFilesDir(null)?.path ?: return false
+        storageLocation.value = extPath
+        Preferences(c).setString(STORAGE_LOCATION, extPath)
+        return true
     }
 }

--- a/app/src/main/java/nz/org/cacophony/sidekick/MainViewModel.kt
+++ b/app/src/main/java/nz/org/cacophony/sidekick/MainViewModel.kt
@@ -20,6 +20,7 @@ class MainViewModel : ViewModel() {
     val recordingUploadingProgress = MutableLiveData<Int>().apply { value = 0 }
     val recordingUploadingCount = MutableLiveData<Int>().apply { value = 0 }
     val locationStatusText = MutableLiveData<String>().apply { value = "" }
+    val storageLocation = MutableLiveData<String>().apply { value = "" }
 
     lateinit var wifiHelper: WifiHelper
     val networkIntentFilter = IntentFilter()
@@ -39,5 +40,12 @@ class MainViewModel : ViewModel() {
         networkIntentFilter.addAction("android.net.conn.CONNECTIVITY_CHANGE")
         networkIntentFilter.addAction("android.net.wifi.WIFI_STATE_CHANGED")
         networkIntentFilter.addAction("android.net.wifi.WIFI_AP_STATE_CHANGED")
+
+        val prefs = Preferences(activity)
+        storageLocation.value = prefs.getString(STORAGE_LOCATION)
+        if (storageLocation.value == "") {
+            storageLocation.value = activity.applicationContext.getExternalFilesDir(null)!!.path
+            prefs.setString(STORAGE_LOCATION, storageLocation.value!!)
+        }
     }
 }

--- a/app/src/main/java/nz/org/cacophony/sidekick/Preferences.kt
+++ b/app/src/main/java/nz/org/cacophony/sidekick/Preferences.kt
@@ -8,11 +8,11 @@ const val STORAGE_LOCATION = "storage-location"
 class Preferences(context: Context) {
     private val prefs: SharedPreferences = context.getSharedPreferences("SETTINGS", Context.MODE_PRIVATE)
 
-    fun getString(key: String): String {
-        return prefs.getString(key, "")!!
+    fun getString(key: String): String? {
+        return prefs.getString(key, null)
     }
 
-    fun setString(key: String, value: String) {
+    fun setString(key: String, value: String?) {
         prefs.edit().putString(key, value).apply()
     }
 }

--- a/app/src/main/java/nz/org/cacophony/sidekick/Preferences.kt
+++ b/app/src/main/java/nz/org/cacophony/sidekick/Preferences.kt
@@ -1,0 +1,18 @@
+package nz.org.cacophony.sidekick
+
+import android.content.Context
+import android.content.SharedPreferences
+
+const val STORAGE_LOCATION = "storage-location"
+
+class Preferences(context: Context) {
+    private val prefs: SharedPreferences = context.getSharedPreferences("SETTINGS", Context.MODE_PRIVATE)
+
+    fun getString(key: String): String {
+        return prefs.getString(key, "")!!
+    }
+
+    fun setString(key: String, value: String) {
+        prefs.edit().putString(key, value).apply()
+    }
+}

--- a/app/src/main/java/nz/org/cacophony/sidekick/fragments/SettingsFragment.kt
+++ b/app/src/main/java/nz/org/cacophony/sidekick/fragments/SettingsFragment.kt
@@ -6,6 +6,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProviders
 import nz.org.cacophony.sidekick.BuildConfig
 import nz.org.cacophony.sidekick.MainViewModel
@@ -15,6 +16,7 @@ class SettingsFragment : Fragment() {
     private var title = "Settings"
 
     private lateinit var mainViewModel: MainViewModel
+    private lateinit var storageLocation: TextView
 
     override fun onCreateView(
             inflater: LayoutInflater,
@@ -24,7 +26,9 @@ class SettingsFragment : Fragment() {
         container?.removeAllViews()
         val root = inflater.inflate(R.layout.fragment_settings, container, false)
         val versionText = root.findViewById<TextView>(R.id.app_version_text)
-        versionText.setText("Sidekick v${BuildConfig.VERSION_NAME}")
+        versionText.text = "v${BuildConfig.VERSION_NAME}"
+        storageLocation = root.findViewById(R.id.settings_storage_location)
+        setViewModelObservers()
         return root
     }
 
@@ -36,5 +40,13 @@ class SettingsFragment : Fragment() {
         } ?: throw Exception("Invalid Activity")
 
         mainViewModel.title.value = title
+    }
+
+    private fun setViewModelObservers() {
+        mainViewModel.storageLocation.observe(this, Observer { updateStorageLocation(it!!) })
+    }
+
+    private fun updateStorageLocation(path: String) {
+        storageLocation.text = path
     }
 }

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -9,12 +9,76 @@
         android:layout_height="match_parent"
         android:orientation="vertical">
 
-        <TextView
-            android:id="@+id/app_version_text"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="16dp"
-            android:text="Sidekick v1.0.0" />
+
+        <ScrollView
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:layout_gravity="">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="40dp"
+                    android:layout_margin="10dp">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center_vertical"
+                        android:layout_marginEnd="10dp"
+                        android:text="Version:" />
+
+                    <TextView
+                        android:id="@+id/app_version_text"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center_vertical"
+                        android:textStyle="bold"
+                        android:text="v1.0.0" />
+
+                </LinearLayout>
+
+                <View
+                    android:layout_width="match_parent"
+                    android:layout_height="1dp"
+                    android:background="@android:color/darker_gray"/>
+
+                <LinearLayout
+                    android:onClick="chooseStorageLocation"
+                    android:layout_width="match_parent"
+                    android:layout_height="40dp"
+                    android:layout_margin="10dp">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center_vertical"
+                        android:layout_marginEnd="10dp"
+                        android:text="Choose storage\nlocation:" />
+
+                    <TextView
+                        android:id="@+id/settings_storage_location"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center_vertical"
+                        android:textStyle="bold"
+                        android:text="/data/" />
+
+
+                </LinearLayout>
+
+                <View
+                    android:layout_width="match_parent"
+                    android:layout_height="1dp"
+                    android:background="@android:color/darker_gray"/>
+
+            </LinearLayout>
+        </ScrollView>
 
         <Button
             android:layout_width="match_parent"
@@ -22,5 +86,9 @@
             android:layout_marginTop="16dp"
             android:onClick="logout"
             android:text="Logout" />
+
+
+
+
     </LinearLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
- Environment.getExternalStorageDirectory() is deprecated and did not work with android 10 and a targetSdkVersion of 29
- Changing storage location won't mean that older recordings that were collected will be lost as the absolute recording file path is stored in the recordings database.


![photo_2020-01-21_18-01-15](https://user-images.githubusercontent.com/9843672/72776746-17b98e00-3c78-11ea-8631-e18c1b076ff9.jpg)
![photo_2020-01-21_18-01-23](https://user-images.githubusercontent.com/9843672/72776748-17b98e00-3c78-11ea-9ff8-dc753897c807.jpg)

